### PR TITLE
Sane wrapper for better readability

### DIFF
--- a/SaneNetScanner.xcodeproj/project.pbxproj
+++ b/SaneNetScanner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AA45B45815CEF529004A8357 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA45B45615CEF517004A8357 /* Carbon.framework */; };
 		AA45B46815CF0451004A8357 /* LoggerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AA45B46615CF0451004A8357 /* LoggerClient.m */; };
 		AA45B46B15CF04F1004A8357 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA45B46A15CF04F1004A8357 /* SystemConfiguration.framework */; };
+		AAC97EC915D0137600B9E327 /* CSSaneOption.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC97EC815D0137600B9E327 /* CSSaneOption.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,8 @@
 		AA45B46715CF0451004A8357 /* LoggerCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoggerCommon.h; sourceTree = "<group>"; };
 		AA45B46915CF0466004A8357 /* Log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Log.h; sourceTree = "<group>"; };
 		AA45B46A15CF04F1004A8357 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		AAC97EC715D0137600B9E327 /* CSSaneOption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSaneOption.h; sourceTree = "<group>"; };
+		AAC97EC815D0137600B9E327 /* CSSaneOption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSSaneOption.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +109,7 @@
 		AA45B42C15CED4D9004A8357 /* SaneNetScanner */ = {
 			isa = PBXGroup;
 			children = (
+				AAC97EC515D0136400B9E327 /* Sane Wrapper */,
 				AA45B46415CF0446004A8357 /* Logging */,
 				AA45B42D15CED4D9004A8357 /* Supporting Files */,
 				AA45B44B15CEEB7B004A8357 /* CSSaneNetScanner.h */,
@@ -155,6 +159,15 @@
 				AA45B46915CF0466004A8357 /* Log.h */,
 			);
 			name = Logging;
+			sourceTree = "<group>";
+		};
+		AAC97EC515D0136400B9E327 /* Sane Wrapper */ = {
+			isa = PBXGroup;
+			children = (
+				AAC97EC715D0137600B9E327 /* CSSaneOption.h */,
+				AAC97EC815D0137600B9E327 /* CSSaneOption.m */,
+			);
+			name = "Sane Wrapper";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -225,6 +238,7 @@
 				AA45B44D15CEEB7B004A8357 /* CSSaneNetScanner.m in Sources */,
 				AA45B45015CEED1E004A8357 /* ICD_Trampolins.m in Sources */,
 				AA45B46815CF0451004A8357 /* LoggerClient.m in Sources */,
+				AAC97EC915D0137600B9E327 /* CSSaneOption.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -352,6 +366,7 @@
 				AA45B44215CED4D9004A8357 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SaneNetScanner.xcodeproj/project.pbxproj
+++ b/SaneNetScanner.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		AA45B46815CF0451004A8357 /* LoggerClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AA45B46615CF0451004A8357 /* LoggerClient.m */; };
 		AA45B46B15CF04F1004A8357 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA45B46A15CF04F1004A8357 /* SystemConfiguration.framework */; };
 		AAC97EC915D0137600B9E327 /* CSSaneOption.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC97EC815D0137600B9E327 /* CSSaneOption.m */; };
+		AAC97ECC15D0289700B9E327 /* CSSaneOptionConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC97ECB15D0289700B9E327 /* CSSaneOptionConstraint.m */; };
+		AAC97ECF15D0297200B9E327 /* CSSaneOptionRangeConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC97ECE15D0297200B9E327 /* CSSaneOptionRangeConstraint.m */; };
+		AAC97ED215D0370500B9E327 /* CSSaneOptionEnumConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC97ED115D0370500B9E327 /* CSSaneOptionEnumConstraint.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +51,12 @@
 		AA45B46A15CF04F1004A8357 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		AAC97EC715D0137600B9E327 /* CSSaneOption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSaneOption.h; sourceTree = "<group>"; };
 		AAC97EC815D0137600B9E327 /* CSSaneOption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSSaneOption.m; sourceTree = "<group>"; };
+		AAC97ECA15D0289700B9E327 /* CSSaneOptionConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSaneOptionConstraint.h; sourceTree = "<group>"; };
+		AAC97ECB15D0289700B9E327 /* CSSaneOptionConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSSaneOptionConstraint.m; sourceTree = "<group>"; };
+		AAC97ECD15D0297200B9E327 /* CSSaneOptionRangeConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSaneOptionRangeConstraint.h; sourceTree = "<group>"; };
+		AAC97ECE15D0297200B9E327 /* CSSaneOptionRangeConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSSaneOptionRangeConstraint.m; sourceTree = "<group>"; };
+		AAC97ED015D0370500B9E327 /* CSSaneOptionEnumConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSaneOptionEnumConstraint.h; sourceTree = "<group>"; };
+		AAC97ED115D0370500B9E327 /* CSSaneOptionEnumConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSSaneOptionEnumConstraint.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +175,12 @@
 			children = (
 				AAC97EC715D0137600B9E327 /* CSSaneOption.h */,
 				AAC97EC815D0137600B9E327 /* CSSaneOption.m */,
+				AAC97ECA15D0289700B9E327 /* CSSaneOptionConstraint.h */,
+				AAC97ECB15D0289700B9E327 /* CSSaneOptionConstraint.m */,
+				AAC97ECD15D0297200B9E327 /* CSSaneOptionRangeConstraint.h */,
+				AAC97ECE15D0297200B9E327 /* CSSaneOptionRangeConstraint.m */,
+				AAC97ED015D0370500B9E327 /* CSSaneOptionEnumConstraint.h */,
+				AAC97ED115D0370500B9E327 /* CSSaneOptionEnumConstraint.m */,
 			);
 			name = "Sane Wrapper";
 			sourceTree = "<group>";
@@ -239,6 +254,9 @@
 				AA45B45015CEED1E004A8357 /* ICD_Trampolins.m in Sources */,
 				AA45B46815CF0451004A8357 /* LoggerClient.m in Sources */,
 				AAC97EC915D0137600B9E327 /* CSSaneOption.m in Sources */,
+				AAC97ECC15D0289700B9E327 /* CSSaneOptionConstraint.m in Sources */,
+				AAC97ECF15D0297200B9E327 /* CSSaneOptionRangeConstraint.m in Sources */,
+				AAC97ED215D0370500B9E327 /* CSSaneOptionEnumConstraint.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SaneNetScanner/CSSaneNetScanner.m
+++ b/SaneNetScanner/CSSaneNetScanner.m
@@ -272,31 +272,6 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
                 @"value": [NSNumber numberWithDouble:height]
             };
         }
-        else if (strcmp(option->name, SANE_NAME_SCAN_MODE) == 0) {
-            
-            NSMutableDictionary* d = [NSMutableDictionary dictionary];
-            
-            d[@"SaneOptionNumber"] = [NSNumber numberWithInt:i];
-            
-            AddConstraintToDict(option, d);
-            
-            // Fetch current
-            SANE_String_Const value = malloc(option->size);
-            status = sane_control_option(self.saneHandle,
-                                         i,
-                                         SANE_ACTION_GET_VALUE,
-                                         value, NULL);
-            
-            if (status != SANE_STATUS_GOOD) {
-                NSLog(@"Get failed");
-                assert(false);
-            }
-            
-            d[@"current"] = [NSString stringWithUTF8String:value];
-            
-            LogMessageCompat(@"Found scan modes %@", d);
-            deviceDict[@"SaneScanMode"] = d;
-        }
     }
     
     // The bitdepth was not an option from the device
@@ -326,7 +301,7 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
     self.documentPath = [[dict[@"document folder"] stringByAppendingPathComponent:dict[@"document name"]] stringByAppendingPathExtension:dict[@"document extension"]];
     
     int unit = [dict[@"ICAP_UNITS"][@"value"] intValue];
-    
+        
     for (CSSaneOption* option in self.saneOptions) {
         if ([option.name isEqualToString:kSaneScanMode] && dict[@"ColorSyncMode"]) {
             NSString* syncMode = dict[@"ColorSyncMode"];

--- a/SaneNetScanner/CSSaneNetScanner.m
+++ b/SaneNetScanner/CSSaneNetScanner.m
@@ -125,7 +125,7 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
     
     SANE_Handle handle;
     SANE_Status status;
-    NSString* deviceName = @"10.0.1.5:mustek_usb:libusb:001:007";
+    NSString* deviceName = @"10.0.1.5:mustek_usb:libusb:001:008";
     
     status = sane_open([deviceName UTF8String], &handle);
     
@@ -188,7 +188,7 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
      @"ICAP_SUPPORTEDSIZES": @{ @"current": @1, @"default": @1, @"type": @"TWON_ENUMERATION", @"value": @[ @1, @2, @3, @4, @5, @10, @0 ]},
     
     
-    @"ICAP_UNITS": @{ @"current": @1, @"default": @0, @"type": @"TWON_ENUMERATION", @"value": @[ @0, @1, @5 ] },
+    @"ICAP_UNITS": @{ @"current": @0, @"default": @0, @"type": @"TWON_ENUMERATION", @"value": @[ @0, @1, @5 ] },
     
     } mutableCopy];
     
@@ -248,13 +248,7 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
             }
         }
         else if (strcmp(option->name, SANE_NAME_SCAN_TL_Y) == 0) {
-            double unitsPerInch;
             double height;
-            
-            if (option->unit == SANE_UNIT_MM)
-                unitsPerInch = 25.4;
-            else
-                unitsPerInch = 72.0;
             
             if (option->constraint_type == SANE_CONSTRAINT_RANGE) {
                 if (option->type == SANE_TYPE_FIXED) {
@@ -265,7 +259,9 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
                 }
             }
             
-            height = height/unitsPerInch;
+            // It expects an inch value here, regardless of what
+            // we specify above?!
+            height = height/25.4;
             
             deviceDict[@"ICAP_PHYSICALHEIGHT"] = @{
                 @"type": @"TWON_ONEVALUE",
@@ -322,6 +318,14 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
             else if (unit == 0 /* Inches */) {
                 // Great nothing to to here =)
                 option.value = dict[@"ICAP_XRESOLUTION"][@"value"];
+            }
+        }
+        else if ([option.name isEqualToString:kSanePreview] && dict[@"scan mode"]) {
+            if ([dict[@"scan mode"] isEqualToString:@"overview"]) {
+                option.value = @1;
+            }
+            else {
+                option.value = @0;
             }
         }
     }

--- a/SaneNetScanner/CSSaneNetScanner.m
+++ b/SaneNetScanner/CSSaneNetScanner.m
@@ -202,6 +202,7 @@ static void AddConstraintToDict(const SANE_Option_Descriptor* descriptior,
             
             [option.constraint addToDeviceDictionary:d];
             d[@"current"] = option.value;
+            d[@"default"] = option.value;
             
             deviceDict[@"ICAP_XRESOLUTION"] = d;
             deviceDict[@"ICAP_YRESOLUTION"] = d;

--- a/SaneNetScanner/CSSaneOption.h
+++ b/SaneNetScanner/CSSaneOption.h
@@ -12,6 +12,7 @@
 
 extern NSString* kSaneScanResolution;
 extern NSString* kSaneScanMode;
+extern NSString* kSanePreview;
 
 @interface CSSaneOption : NSObject
 

--- a/SaneNetScanner/CSSaneOption.h
+++ b/SaneNetScanner/CSSaneOption.h
@@ -6,7 +6,12 @@
 //  Copyright (c) 2012 Christian Speich. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #include "sane/sane.h"
+#import "CSSaneOptionConstraint.h"
+
+extern NSString* kSaneScanResolution;
+extern NSString* kSaneScanMode;
 
 @interface CSSaneOption : NSObject
 
@@ -18,5 +23,7 @@
 // Note: setting it will talk to the device
 // getting it may do also so
 @property (nonatomic, copy) id value;
+
+@property (nonatomic, strong, readonly) CSSaneOptionConstraint* constraint;
 
 @end

--- a/SaneNetScanner/CSSaneOption.h
+++ b/SaneNetScanner/CSSaneOption.h
@@ -1,0 +1,22 @@
+//
+//  CSSaneOption.h
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#include "sane/sane.h"
+
+@interface CSSaneOption : NSObject
+
++ (NSArray*) saneOptionsForHandle:(SANE_Handle)handle;
+
+@property (nonatomic, copy, readonly) NSString* name;
+
+// The Value may be an string or an number
+// Note: setting it will talk to the device
+// getting it may do also so
+@property (nonatomic, copy) id value;
+
+@end

--- a/SaneNetScanner/CSSaneOption.m
+++ b/SaneNetScanner/CSSaneOption.m
@@ -295,6 +295,27 @@ NSString* kSaneScanMode = (NSString*)CFSTR(SANE_NAME_SCAN_MODE);
             return;
         }
     }
+    else if (self.descriptor->type == SANE_TYPE_BOOL) {
+        if (self.descriptor->size != sizeof(SANE_Bool)) {
+            LogMessageCompat(@"Dont support multi-size bool type set yet.");
+            return;
+        }
+        
+        SANE_Bool value = [self.value intValue];
+        SANE_Status status;
+        
+        LogMessageCompat(@"Set \"%@\" to \"%@\"", self.name, value ? @"true" : @"false");
+        status = sane_control_option(self.saneHandle,
+                                     self.saneOptionNumber,
+                                     SANE_ACTION_SET_VALUE,
+                                     &value,
+                                     0);
+        
+        if (status != SANE_STATUS_GOOD) {
+            LogMessageCompat(@"Set failed %@: %s", self, sane_strstatus(status));
+            return;
+        }
+    }
     else {
         LogMessageCompat(@"Unsuported set type.");
     }

--- a/SaneNetScanner/CSSaneOption.m
+++ b/SaneNetScanner/CSSaneOption.m
@@ -12,6 +12,8 @@
 
 NSString* kSaneScanResolution = (NSString*)CFSTR(SANE_NAME_SCAN_RESOLUTION);
 NSString* kSaneScanMode = (NSString*)CFSTR(SANE_NAME_SCAN_MODE);
+NSString* kSanePreview = (NSString*)CFSTR(SANE_NAME_PREVIEW);
+
 
 @interface CSSaneOption ()
 

--- a/SaneNetScanner/CSSaneOption.m
+++ b/SaneNetScanner/CSSaneOption.m
@@ -1,0 +1,187 @@
+//
+//  CSSaneOption.m
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import "CSSaneOption.h"
+
+@interface CSSaneOption ()
+
+@property (nonatomic, copy) NSString* name;
+@property (nonatomic) SANE_Handle saneHandle;
+@property (nonatomic) SANE_Int saneOptionNumber;
+
+@property (nonatomic) const SANE_Option_Descriptor* descriptor;
+
+- (void) _fetchValue;
+- (void) _setValue;
+
+@end
+
+@implementation CSSaneOption
+
+@synthesize value = _value;
+
++ (NSArray*) saneOptionsForHandle:(SANE_Handle)handle
+{
+    SANE_Int number;
+    NSMutableArray* options = [NSMutableArray array];
+    
+    for (number = 0;; number++) {
+        const SANE_Option_Descriptor* descriptor =
+        sane_get_option_descriptor(handle, number);
+        
+        // Last descriptor
+        if (descriptor == NULL)
+            break;
+        
+        // Discard group
+        if (descriptor->type == SANE_TYPE_GROUP)
+            continue;
+        
+        [options addObject:[[self alloc] initWithHandle:handle
+                                                 number:number
+                                          andDescriptor:descriptor]];
+    }
+    
+    return options;
+}
+
+- (id)initWithHandle:(SANE_Handle)handle
+              number:(SANE_Int)number
+       andDescriptor:(const SANE_Option_Descriptor*)descriptor
+{
+    self = [super init];
+    if (self) {
+        self.name = [NSString stringWithUTF8String:descriptor->name];
+        
+        self.descriptor = descriptor;
+        self.saneHandle = handle;
+        self.saneOptionNumber = number;
+        
+        [self _fetchValue];
+    }
+    return self;
+}
+
+- (void) setValue:(id)value
+{
+    if ([value isEqual:_value])
+        return;
+    
+    _value = value;
+    [self _setValue];
+}
+
+- (void) _fetchValue
+{
+    if (self.descriptor->type == SANE_TYPE_FIXED) {
+        SANE_Fixed *values;
+        SANE_Status status;
+        
+        values = malloc(self.descriptor->size);
+        
+        status = sane_control_option(self.saneHandle,
+                                     self.saneOptionNumber,
+                                     SANE_ACTION_GET_VALUE,
+                                     values, 0);
+        
+        if (status != SANE_STATUS_GOOD) {
+            LogMessageCompat(@"Failed get %@: %s", self, sane_strstatus(status));
+            return;
+        }
+        
+        // Only one value
+        if (self.descriptor->size == sizeof(SANE_Int)) {
+            _value = [NSNumber numberWithDouble:SANE_UNFIX(values[0])];
+        }
+        // Multiple values
+        else {
+            NSUInteger numberOfValues = self.descriptor->size/sizeof(SANE_Int);
+            NSMutableArray* valueArray = [NSMutableArray arrayWithCapacity:numberOfValues];
+            
+            for (NSUInteger i = 0; i < numberOfValues; i++) {
+                [valueArray addObject:
+                 [NSNumber numberWithDouble:SANE_UNFIX(values[i])]];
+            }
+            
+            _value = valueArray;
+        }
+        
+        free(values);
+    }
+    else if (self.descriptor->type == SANE_TYPE_INT) {
+        SANE_Int *values;
+        SANE_Status status;
+        
+        values = malloc(self.descriptor->size);
+        
+        status = sane_control_option(self.saneHandle,
+                                     self.saneOptionNumber,
+                                     SANE_ACTION_GET_VALUE,
+                                     values, 0);
+        
+        if (status != SANE_STATUS_GOOD) {
+            LogMessageCompat(@"Failed get %@: %s", self, sane_strstatus(status));
+            return;
+        }
+        
+        // Only one value
+        if (self.descriptor->size == sizeof(SANE_Int)) {
+            _value = [NSNumber numberWithInt:values[0]];
+        }
+        // Multiple values
+        else {
+            NSUInteger numberOfValues = self.descriptor->size/sizeof(SANE_Int);
+            NSMutableArray* valueArray = [NSMutableArray arrayWithCapacity:numberOfValues];
+            
+            for (NSUInteger i = 0; i < numberOfValues; i++) {
+                [valueArray addObject:
+                 [NSNumber numberWithDouble:values[i]]];
+            }
+            
+            _value = valueArray;
+        }
+        
+        free(values);
+    }
+    else if (self.descriptor->type == SANE_TYPE_STRING) {
+        SANE_String value;
+        SANE_Status status;
+        
+        value = malloc(self.descriptor->size);
+        
+        assert(value);
+        
+        status = sane_control_option(self.saneHandle,
+                                     self.saneOptionNumber,
+                                     SANE_ACTION_GET_VALUE,
+                                     value, 0);
+        
+        if (status != SANE_STATUS_GOOD) {
+            LogMessageCompat(@"Failed get %@: %s", self, sane_strstatus(status));
+            return;
+        }
+        
+        _value = [NSString stringWithUTF8String:value];
+        free(value);
+    }
+    else {
+        LogMessageCompat(@"Unsupported type %@", self);
+    }
+}
+
+- (void) _setValue
+{
+    
+}
+
+- (NSString*)description
+{
+    return [NSString stringWithFormat:@"<SaneOption:%p> (name=%@, value=%@)", self, self.name, self.value];
+}
+
+@end

--- a/SaneNetScanner/CSSaneOption.m
+++ b/SaneNetScanner/CSSaneOption.m
@@ -274,6 +274,27 @@ NSString* kSaneScanMode = (NSString*)CFSTR(SANE_NAME_SCAN_MODE);
             return;
         }
     }
+    else if (self.descriptor->type == SANE_TYPE_INT) {
+        if (self.descriptor->size != sizeof(SANE_Int)) {
+            LogMessageCompat(@"Dont support multi-size int type set yet.");
+            return;
+        }
+        
+        SANE_Int value = [self.value intValue];
+        SANE_Status status;
+        
+        LogMessageCompat(@"Set \"%@\" to \"%@\"", self.name, self.value);
+        status = sane_control_option(self.saneHandle,
+                                     self.saneOptionNumber,
+                                     SANE_ACTION_SET_VALUE,
+                                     &value,
+                                     0);
+        
+        if (status != SANE_STATUS_GOOD) {
+            LogMessageCompat(@"Set failed %@: %s", self, sane_strstatus(status));
+            return;
+        }
+    }
     else {
         LogMessageCompat(@"Unsuported set type.");
     }

--- a/SaneNetScanner/CSSaneOptionConstraint.h
+++ b/SaneNetScanner/CSSaneOptionConstraint.h
@@ -1,0 +1,25 @@
+//
+//  CSSaneOptionConstraint.h
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#include "sane/sane.h"
+
+typedef enum {
+    CSSaneRangeConstraint,
+    CSSaneEnumConstraint
+} CSSaneConstraintType;
+
+@interface CSSaneOptionConstraint : NSObject
+
++ (id) constraintWithDescriptor:(const SANE_Option_Descriptor*)descriptor;
+
+@property (nonatomic, readonly) CSSaneConstraintType type;
+
+- (void) addToDeviceDictionary:(NSMutableDictionary*)dict;
+
+@end

--- a/SaneNetScanner/CSSaneOptionConstraint.m
+++ b/SaneNetScanner/CSSaneOptionConstraint.m
@@ -1,0 +1,30 @@
+//
+//  CSSaneOptionConstraint.m
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import "CSSaneOptionConstraint.h"
+#import "CSSaneOptionRangeConstraint.h"
+#import "CSSaneOptionEnumConstraint.h"
+
+@implementation CSSaneOptionConstraint
+
++ (id) constraintWithDescriptor:(const SANE_Option_Descriptor*)descriptor
+{
+    if (descriptor->constraint_type == SANE_CONSTRAINT_RANGE)
+        return [[CSSaneOptionRangeConstraint alloc] initWithDescriptor:descriptor];
+    else if (descriptor->constraint_type == SANE_CONSTRAINT_STRING_LIST ||
+             descriptor->constraint_type == SANE_CONSTRAINT_WORD_LIST)
+        return [[CSSaneOptionEnumConstraint alloc] initWithDescriptor:descriptor];
+    
+    return nil;
+}
+
+- (void) addToDeviceDictionary:(NSMutableDictionary*)dict
+{
+}
+
+@end

--- a/SaneNetScanner/CSSaneOptionEnumConstraint.h
+++ b/SaneNetScanner/CSSaneOptionEnumConstraint.h
@@ -1,0 +1,17 @@
+//
+//  CSSaneOptionEnumConstraint.h
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import "CSSaneOptionConstraint.h"
+
+@interface CSSaneOptionEnumConstraint : CSSaneOptionConstraint
+
+- (id) initWithDescriptor:(const SANE_Option_Descriptor*)descriptor;
+
+@property (nonatomic, copy, readonly) NSArray* values;
+
+@end

--- a/SaneNetScanner/CSSaneOptionEnumConstraint.m
+++ b/SaneNetScanner/CSSaneOptionEnumConstraint.m
@@ -1,0 +1,71 @@
+//
+//  CSSaneOptionEnumConstraint.m
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import "CSSaneOptionEnumConstraint.h"
+
+@interface CSSaneOptionEnumConstraint ()
+
+@property (nonatomic, copy) NSArray* values;
+
+@end
+
+@implementation CSSaneOptionEnumConstraint
+
+- (id) initWithDescriptor:(const SANE_Option_Descriptor*)descriptor
+{
+    self = [super init];
+    if (self) {
+        assert(descriptor->constraint_type == SANE_CONSTRAINT_STRING_LIST ||
+               descriptor->constraint_type == SANE_CONSTRAINT_WORD_LIST);
+        
+        if (descriptor->constraint_type == SANE_CONSTRAINT_WORD_LIST) {
+            SANE_Word length = descriptor->constraint.word_list[0];
+            NSMutableArray* values = [NSMutableArray arrayWithCapacity:length];
+            
+            for (SANE_Word i = 1; i < length + 1; i++) {
+                if (descriptor->type == SANE_TYPE_FIXED) {
+                    [values addObject:[NSNumber numberWithDouble:SANE_UNFIX(descriptor->constraint.word_list[i])]];
+                }
+                else if (descriptor->type == SANE_TYPE_INT) {
+                    [values addObject:[NSNumber numberWithInt:descriptor->constraint.word_list[i]]];
+                }
+                else {
+                    assert(false);
+                }
+            }
+            
+            self.values = values;
+        }
+        else {
+            NSMutableArray* values = [NSMutableArray array];
+            const char* const * ptr = descriptor->constraint.string_list;
+            
+            while (*ptr != NULL) {
+                const char* const str = *ptr;
+                
+                [values addObject:[NSString stringWithUTF8String:str]];
+                
+                ptr++;
+            }
+            
+            self.values = values;
+        }
+    }
+    return self;
+}
+
+- (CSSaneConstraintType) type
+{
+    return CSSaneEnumConstraint;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@:%p> %@", NSStringFromClass([self class]), self, self.values];
+}
+
+@end

--- a/SaneNetScanner/CSSaneOptionRangeConstraint.h
+++ b/SaneNetScanner/CSSaneOptionRangeConstraint.h
@@ -1,0 +1,19 @@
+//
+//  CSSaneOptionRangeConstraint.h
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import "CSSaneOptionConstraint.h"
+
+@interface CSSaneOptionRangeConstraint : CSSaneOptionConstraint
+
+- (id) initWithDescriptor:(const SANE_Option_Descriptor*)descriptor;
+
+@property (nonatomic, copy, readonly) NSNumber* minValue;
+@property (nonatomic, copy, readonly) NSNumber* maxValue;
+@property (nonatomic, copy, readonly) NSNumber* step;
+
+@end

--- a/SaneNetScanner/CSSaneOptionRangeConstraint.m
+++ b/SaneNetScanner/CSSaneOptionRangeConstraint.m
@@ -1,0 +1,60 @@
+//
+//  CSSaneOptionRangeConstraint.m
+//  SaneNetScanner
+//
+//  Created by Christian Speich on 06.08.12.
+//  Copyright (c) 2012 Christian Speich. All rights reserved.
+//
+
+#import "CSSaneOptionRangeConstraint.h"
+
+@interface CSSaneOptionRangeConstraint ()
+
+@property (nonatomic, copy) NSNumber* minValue;
+@property (nonatomic, copy) NSNumber* maxValue;
+@property (nonatomic, copy) NSNumber* step;
+
+@end
+
+@implementation CSSaneOptionRangeConstraint
+
+- (id) initWithDescriptor:(const SANE_Option_Descriptor*)descriptor
+{
+    self = [super init];
+    if (self) {
+        assert(descriptor->constraint_type == SANE_CONSTRAINT_RANGE);
+        assert(descriptor->type == SANE_TYPE_INT ||
+               descriptor->type == SANE_TYPE_FIXED);
+        
+        if (descriptor->type == SANE_TYPE_INT) {
+            self.minValue = [NSNumber numberWithInt:descriptor->constraint.range->min];
+            self.maxValue = [NSNumber numberWithInt:descriptor->constraint.range->max];
+            self.step = [NSNumber numberWithInt:descriptor->constraint.range->quant];
+        }
+        else {
+            self.minValue = [NSNumber numberWithDouble:SANE_UNFIX(descriptor->constraint.range->min)];
+            self.maxValue = [NSNumber numberWithDouble:SANE_UNFIX(descriptor->constraint.range->max)];
+            self.step = [NSNumber numberWithDouble:SANE_UNFIX(descriptor->constraint.range->quant)];
+        }
+    }
+    return self;
+}
+
+- (CSSaneConstraintType) type
+{
+    return CSSaneRangeConstraint;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@:%p> (min=%@, max=%@, step=%@)", NSStringFromClass([self class]), self, self.minValue, self.maxValue, self.step];
+}
+
+- (void) addToDeviceDictionary:(NSMutableDictionary*)dict
+{
+    dict[@"type"] = @"TWON_RANGE";
+    dict[@"min"] = self.minValue;
+    dict[@"max"] = self.maxValue;
+    dict[@"stepSize"] = self.step;
+}
+
+@end

--- a/SaneNetScanner/main.m
+++ b/SaneNetScanner/main.m
@@ -10,12 +10,19 @@
 #import "ICD_Trampolins.h"
 #import "sane/sane.h"
 
+void AuthCallBack(SANE_String_Const resource,
+                  SANE_Char *username,
+                  SANE_Char *password) {
+    username = "";
+    password = "";
+}
+
 int main(int argc, char *argv[])
 {
     int status = 0;
     SANE_Status saneStatus;
     
-    saneStatus = sane_init(NULL, NULL);
+    saneStatus = sane_init(NULL, &AuthCallBack);
     
     if (saneStatus != SANE_STATUS_GOOD) {
         NSLog(@"Sane init failed");


### PR DESCRIPTION
In order to clean up the code, the sane option retrieval and setting should be wrapped up in objc.
